### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/msanlisavas/CSPR.Cloud.Net/security/code-scanning/1](https://github.com/msanlisavas/CSPR.Cloud.Net/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root, right after the `on:` triggers and before `jobs:`.  
For this workflow, the least-privilege baseline is:

- `contents: read`

This preserves existing functionality (checkout + restore/build) while constraining `GITHUB_TOKEN` access. No imports, methods, or additional definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
